### PR TITLE
Align customer delete button styling with other actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -918,7 +918,7 @@ function closeNewTaskUI(){
             <button type="button" class="btn-icon" data-act="manual" data-id="${c.id}" title="Set next FU (manual)" aria-label="Manual next FU">📅</button>
             <button type="button" class="btn-icon" data-act="edit"  data-id="${c.id}" title="Edit" aria-label="Edit">🖊️</button>
             <button type="button" class="btn-icon" data-act="reach" data-id="${c.id}" title="${c.status==='unreached'?'Mark Reached':'Mark Unreached'}" aria-label="${c.status==='unreached'?'Mark Reached':'Mark Unreached'}">${c.status==='unreached'?'✅':'↩️'}</button>
-            <button type="button" class="btn-icon btn-danger" data-act="del"   data-id="${c.id}" title="Delete" aria-label="Delete">🗑️</button>
+            <button type="button" class="btn-icon" data-act="del"   data-id="${c.id}" title="Delete" aria-label="Delete">🗑️</button>
           </td>`;
         body.appendChild(tr);
       });


### PR DESCRIPTION
## Summary
- Remove red `btn-danger` styling from customer delete button so it matches other action buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f042c4e808326895f8ff5f46cfed6